### PR TITLE
Update unit tests

### DIFF
--- a/apps/sharedtest/test/unit/icons_helper_test.js
+++ b/apps/sharedtest/test/unit/icons_helper_test.js
@@ -31,7 +31,8 @@ suite('Icons Helper', function() {
   suite('Default fallback to favicon.ico', function() {
     test('> ensure we fallback to favicon.ico', function(done) {
       IconsHelper.getIcon('http://example.com').then(icon => {
-        assert.equal(icon, 'http://example.com/favicon.ico');
+
+        assert.equal((new URL(icon)).pathname, '/favicon.ico');
         done();
       });
     });
@@ -189,6 +190,30 @@ suite('Icons Helper', function() {
       dpr = 1;
     });
 
+  });
+
+  suite('> -moz-resolution fragment', function() {
+    teardown(function() {
+      dpr = 1;
+    });
+
+    test('no target size', function(done) {
+      IconsHelper.getIcon('http://example.com').then(icon => {
+        assert.equal((new URL(icon)).hash, '');
+      })
+      .then((res) => { done(); })
+      .catch((err) => { done(); });
+    });
+
+    test('target size', function(done) {
+      dpr = 1.5;
+      IconsHelper.getIcon('http://example.com', 64).then(icon => {
+        // targetSize * devicePixelRatio
+        assert.ok((new URL(icon)).hash.indexOf('-moz-resolution=96,96') > -1);
+      })
+      .then((res) => { done(); })
+      .catch((err) => { done(); });
+    });
   });
 
 });

--- a/apps/system/js/app_chrome.js
+++ b/apps/system/js/app_chrome.js
@@ -939,7 +939,7 @@
 
     this.app.getSiteIconUrl()
       .then(iconObject => {
-        console.log(iconObject)
+        this.debug('iconObject:', iconObject);
 
         this.siteIcon.classList.toggle('small-icon', iconObject.isSmall);
         this.siteIcon.style.backgroundImage = `url("${iconObject.url}")`;

--- a/apps/system/test/unit/app_chrome_test.js
+++ b/apps/system/test/unit/app_chrome_test.js
@@ -1,5 +1,5 @@
 /* global AppWindow, AppChrome, MocksHelper, MockL10n, PopupWindow,
-          MockModalDialog, MockService */
+          MockModalDialog, MockService, MockPromise */
 /* exported MockBookmarksDatabase */
 'use strict';
 
@@ -9,6 +9,7 @@ require('/shared/elements/gaia_progress/script.js');
 require('/shared/test/unit/mocks/mock_l10n.js');
 require('/shared/test/unit/mocks/mock_lazy_loader.js');
 require('/shared/test/unit/mocks/mock_service.js');
+require('/shared/test/unit/mocks/mock_promise.js');
 requireApp('system/test/unit/mock_app_window.js');
 requireApp('system/test/unit/mock_popup_window.js');
 requireApp('system/test/unit/mock_modal_dialog.js');
@@ -37,7 +38,7 @@ suite('system/AppChrome', function() {
     stubById.returns(document.createElement('div'));
     requireApp('system/js/base_ui.js');
     requireApp('system/js/app_chrome.js', function() {
-      app = new AppWindow(fakeWebSite);
+      app = new AppWindow(cloneConfig(fakeWebSite));
       app.contextmenu = {
         isShown: function() {return false;}
       };
@@ -53,6 +54,9 @@ suite('system/AppChrome', function() {
     stubById.restore();
   });
 
+  function cloneConfig(config) {
+    return JSON.parse(JSON.stringify(config));
+  }
   var fakeWebSite = {
     url: 'http://google.com/index.html',
     origin: 'app://google.com',
@@ -153,7 +157,7 @@ suite('system/AppChrome', function() {
     });
 
     test('app ssl state is changed', function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
       this.sinon.stub(app, 'getSSLState', function() {
         return 'broken';
       });
@@ -176,7 +180,7 @@ suite('system/AppChrome', function() {
     });
 
     test('Combined view for navigation + bar', function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
 
       var spyView = this.sinon.spy(AppChrome.prototype, 'combinedView');
       new AppChrome(app); // jshint ignore:line
@@ -291,11 +295,17 @@ suite('system/AppChrome', function() {
     test('loadstart', function() {
       chrome.handleEvent({ type: 'mozbrowserloadstart' });
       assert.isTrue(chrome.containerElement.classList.contains('loading'));
+      assert.ok(chrome.setSiteIcon.calledOnce);
+      assert.equal(1, chrome.setSiteIcon.getCall(0).args.length,
+                'setSiteIcon passed default URL argument');
     });
 
     test('loadend', function() {
       chrome.handleEvent({ type: 'mozbrowserloadend' });
       assert.isFalse(chrome.containerElement.classList.contains('loading'));
+      assert.ok(chrome.setSiteIcon.calledOnce);
+      assert.equal(0, chrome.setSiteIcon.getCall(0).args.length,
+                'setSiteIcon passed 0 argument');
     });
 
     test('namechanged - does not set when we have a fixed title', function() {
@@ -327,7 +337,7 @@ suite('system/AppChrome', function() {
       var app, chrome;
 
       setup(function() {
-        app = new AppWindow(fakeWebSite);
+        app = new AppWindow(cloneConfig(fakeWebSite));
       });
 
       test('scrollable chrome without bar', function() {
@@ -373,14 +383,14 @@ suite('system/AppChrome', function() {
     });
 
     test('should set the name when created', function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
       app.name = 'Phone';
       var chrome = new AppChrome(app);
       assert.equal(chrome.title.textContent, 'Phone');
     });
 
     test('should update the name when it changes', function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
       app.name = 'Phone';
       var chrome = new AppChrome(app);
       assert.equal(chrome.title.textContent, 'Phone');
@@ -393,7 +403,7 @@ suite('system/AppChrome', function() {
 
     test('localized app is not immediately overridden by titlechange event',
       function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
       app.name = 'Phone';
 
       var chrome = new AppChrome(app);
@@ -406,7 +416,7 @@ suite('system/AppChrome', function() {
   suite('mozbrowserlocationchange', function() {
     var subject = null;
     setup(function() {
-      var website = new AppWindow(fakeWebSite);
+      var website = new AppWindow(cloneConfig(fakeWebSite));
       subject = new AppChrome(website);
       subject._registerEvents();
     });
@@ -489,7 +499,7 @@ suite('system/AppChrome', function() {
     var subject = null;
     var cbSpy = null;
     setup(function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
       subject = new AppChrome(app);
       cbSpy = this.sinon.spy();
 
@@ -513,7 +523,7 @@ suite('system/AppChrome', function() {
     });
 
     test('collapse should remove the maximized css class', function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
       var subject = new AppChrome(app);
       subject.element.classList.add('maximized');
 
@@ -522,7 +532,7 @@ suite('system/AppChrome', function() {
     });
 
     test('rocketbar-overlayclosed should collapse the urlbar', function() {
-      var app = new AppWindow(fakeWebSite);
+      var app = new AppWindow(cloneConfig(fakeWebSite));
       var subject = new AppChrome(app);
       subject.maximize();
 
@@ -536,7 +546,7 @@ suite('system/AppChrome', function() {
 
     setup(function() {
       this.sinon.clock.restore();
-      app = new AppWindow(fakeWebSite);
+      app = new AppWindow(cloneConfig(fakeWebSite));
       chrome = new AppChrome(app);
       stubRequestAnimationFrame =
         this.sinon.stub(window, 'requestAnimationFrame').yieldsAsync();
@@ -612,6 +622,7 @@ suite('system/AppChrome', function() {
     });
 
     test('theme resets on navigation', function() {
+      this.sinon.stub(chrome, 'setSiteIcon');
       chrome.setThemeColor('orange');
       chrome.handleEvent({type: 'mozbrowserloadstart'});
       chrome.handleEvent({type: 'mozbrowserloadend'});
@@ -647,7 +658,7 @@ suite('system/AppChrome', function() {
     });
 
     test('popup window will use rear window color theme', function(done) {
-      var popup = new PopupWindow(fakeWebSite);
+      var popup = new PopupWindow(cloneConfig(fakeWebSite));
       var popupChrome = new AppChrome(popup);
       this.sinon.stub(popup, 'getBottomMostWindow').returns(app);
       chrome.setThemeColor('black');
@@ -708,7 +719,7 @@ suite('system/AppChrome', function() {
     });
 
     test('does not set for private windows', function() {
-      app = new AppWindow(fakeWebSite);
+      app = new AppWindow(cloneConfig(fakeWebSite));
       this.sinon.stub(app, 'isPrivateBrowser').returns(true);
       chrome = new AppChrome(app);
       assert.equal(chrome.scrollable.style.backgroundColor, '');
@@ -820,9 +831,66 @@ suite('system/AppChrome', function() {
     });
 
     test('should only publish once', function() {
+      console.log('should only publish once');
       chrome.element.dispatchEvent(new CustomEvent('transitionend'));
       this.sinon.clock.tick(250);
       sinon.assert.calledOnce(app.publish.withArgs('chromecollapsed'));
     });
+  });
+
+  suite('setSiteIcon', function() {
+    var fakeIconURI = 'data://someimage';
+    var getIconPromise;
+    var combinedChrome;
+
+    setup(function() {
+      var app = new AppWindow(cloneConfig(fakeWebSite));
+      combinedChrome = new AppChrome(app);
+      getIconPromise = new MockPromise();
+      this.sinon.stub(combinedChrome.app, 'getSiteIconUrl')
+                     .returns(getIconPromise);
+    });
+
+    test('asks app for url when no argument is provided', function() {
+      assert.ok(combinedChrome.useCombinedChrome());
+      combinedChrome.setSiteIcon();
+      getIconPromise.mFulfillToValue({ url: fakeIconURI });
+
+      assert.ok(combinedChrome.siteIcon
+                  .style.backgroundImage.includes(fakeIconURI));
+    });
+
+    test('small icon', function() {
+      combinedChrome.setSiteIcon();
+      getIconPromise.mFulfillToValue({ url: fakeIconURI, isSmall: true });
+
+      assert.isTrue(combinedChrome.siteIcon.classList.contains('small-icon'));
+    });
+
+    test('!small icon', function() {
+      combinedChrome.setSiteIcon();
+      getIconPromise.mFulfillToValue({ url: fakeIconURI, isSmall: false });
+
+      assert.isFalse(combinedChrome.siteIcon.classList.contains('small-icon'));
+    });
+
+    test('handles url argument', function() {
+      combinedChrome.setSiteIcon(fakeIconURI);
+      assert.ok(combinedChrome.siteIcon
+                  .style.backgroundImage.includes(fakeIconURI));
+      sinon.assert.notCalled(combinedChrome.app.getSiteIconUrl);
+    });
+
+    test('failure to get icon', function() {
+      // set a default
+      combinedChrome.siteIcon.style.backgroundImage = `url(${fakeIconURI})`;
+
+      combinedChrome.setSiteIcon();
+      getIconPromise.mRejectToError();
+
+      assert.ok(combinedChrome.siteIcon
+                  .style.backgroundImage.includes(fakeIconURI));
+    });
+
   });
 });

--- a/apps/system/test/unit/app_chrome_test.js
+++ b/apps/system/test/unit/app_chrome_test.js
@@ -284,6 +284,10 @@ suite('system/AppChrome', function() {
 
 
   suite('Navigation events', function() {
+    setup(function() {
+      this.sinon.stub(chrome, 'setSiteIcon');
+    });
+
     test('loadstart', function() {
       chrome.handleEvent({ type: 'mozbrowserloadstart' });
       assert.isTrue(chrome.containerElement.classList.contains('loading'));

--- a/shared/js/icons_helper.js
+++ b/shared/js/icons_helper.js
@@ -7,12 +7,13 @@
  */
 (function IconsHelper(exports) {
   const FETCH_XHR_TIMEOUT = 10000;
+  const DEBUG = false;
 
   var dataStore = null;
 
   /**
-   * Return a promise that resolves to the URL of the best icon for a web page given its meta
-   * data and web manifest.
+   * Return a promise that resolves to the URL of the best icon for a web page
+   * given its meta data and web manifest.
    *
    * @param uri {string}
    * @param iconTargetSize {number}
@@ -28,26 +29,28 @@
     // First look for an icon in the manifest.
     if (siteObj.webManifestUrl && siteObj.webManifest) {
       iconUrl = getBestIconFromWebManifest(siteObj, iconTargetSize);
-      if (iconUrl) {
-        console.log('Icon from Web Manifest')
+      if (DEBUG && iconUrl) {
+        console.log('Icon from Web Manifest');
       }
     }
 
     // Otherwise, look into the meta tags.
     if (!iconUrl && placeObj.icons) {
       iconUrl = getBestIconFromMetaTags(placeObj.icons, iconTargetSize);
-      if (iconUrl) {
-        console.log('Icon from Meta tags')
+      if (DEBUG && iconUrl) {
+        console.log('Icon from Meta tags');
       }
     }
 
     // Last resort, we look for a favicon.ico file.
     if (!iconUrl) {
-      console.log('Icon from favicon.ico')
+      DEBUG && console.log('Icon from favicon.ico');
       var a = document.createElement('a');
       a.href = uri;
-      iconUrl =
-        `${a.origin}/favicon.ico#-moz-resolution=${iconTargetSize},${iconTargetSize}`;
+      iconUrl = a.origin + '/favicon.ico';
+      if (iconTargetSize) {
+        iconUrl += '#-moz-resolution=' + iconTargetSize + ',' + iconTargetSize;
+      }
     }
 
     return new Promise(resolve => {
@@ -57,8 +60,8 @@
 
 
   /**
-   * Same as above except the promise resolves as an object containing the blob of the icon and
-   * its size in pixels.
+   * Same as above except the promise resolves as an object containing the blob
+   * of the icon and its size in pixels.
    *
    * @param uri {string}
    * @param iconTargetSize {number}
@@ -76,7 +79,8 @@
               if (!iconObj) {
                 return fetchIcon(iconUrl)
                   .then(iconObject => {
-                    // We resolve here to avoid I/O blocking on dataStore and quicker display.
+                    // We resolve here to avoid I/O blocking on dataStore and
+                    // quicker display.
                     // Persisting to the dataStore takes place subsequently.
                     resolve(iconObject);
 
@@ -87,7 +91,7 @@
                   });
               }
 
-              return resolve(iconObject);
+              return resolve(iconObj);
             }).catch(err => {
               // We should fetch the icon and resolve the promise here, anyhow.
               reject(`Failed to get icon from dataStore: ${err}`);


### PR DESCRIPTION
I've got the existing tests passing again, and added/changed tests for AppChrome and made a start on IconsHelper. There's more to do there - namely the placeObj and siteObj arguments handling in getIcon, the getIconBlob method and getBestIconFromWebManifest. I would have gotten further but I stumbled into a booby-trap left for me in the AppChrome tests - config is of course passed by reference so although the AppWindow instance was made anew each test, the config was mutable and changed state with each test preceeding - it was entirely coincidental that the tests worked at all!
